### PR TITLE
Implement [CBlock|CBlockIndex]::GetBaseVersion()

### DIFF
--- a/src/core.h
+++ b/src/core.h
@@ -33,6 +33,7 @@ static const int BLOCK_VERSION_DEFAULT = (1 << 0);
 static const int BLOCK_VERSION_AUXPOW = (1 << 8);
 static const int BLOCK_VERSION_CHAIN_START = (1 << 16);
 static const int BLOCK_VERSION_CHAIN_END = (1 << 30);
+static const int BLOCK_VERSION_BASE_MASK = 0x000000ff;
 
 // DogeCoin aux chain ID = 0x0062 (98)
 static const int AUXPOW_CHAIN_ID = 0x0062;
@@ -394,6 +395,12 @@ public:
     int GetChainID() const
     {
         return nVersion / BLOCK_VERSION_CHAIN_START;
+    }
+
+    // base block version without auxpow chain
+    int GetBaseVersion() const
+    {
+        return nVersion & BLOCK_VERSION_BASE_MASK;
     }
 
     void SetAuxPow(CAuxPow* pow);

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -1966,7 +1966,7 @@ bool ConnectBlock(CBlock& block, CValidationState& state, CBlockIndex* pindex, C
     unsigned int flags = SCRIPT_VERIFY_NOCACHE |
                          (fStrictPayToScriptHash ? SCRIPT_VERIFY_P2SH : SCRIPT_VERIFY_NONE);
 
-    if (block.nVersion >= 3 &&
+    if (block.GetBaseVersion() >= 3 &&
         ((!TestNet() && CBlockIndex::IsSuperMajority(3, pindex->pprev, 750, 1000)) ||
             (TestNet() && CBlockIndex::IsSuperMajority(3, pindex->pprev, 51, 100)))) {
         flags |= SCRIPT_VERIFY_DERSIG;
@@ -2137,7 +2137,7 @@ void static UpdateTip(CBlockIndex *pindexNew) {
         const CBlockIndex* pindex = chainActive.Tip();
         for (int i = 0; i < 100 && pindex != NULL; i++)
         {
-            if (pindex->nVersion > CBlock::CURRENT_VERSION && !IsAuxPowVersion(pindex->nVersion))
+            if (pindex->GetBaseVersion() > CBlock::CURRENT_VERSION)
                 ++nUpgraded;
             pindex = pindex->pprev;
         }
@@ -2713,7 +2713,7 @@ bool AcceptBlockHeader(CBlockHeader& block, CValidationState& state, CBlockIndex
             return state.DoS(100, error("AcceptBlock() : forked chain older than last checkpoint (height %d)", nHeight));
 
         // Reject block.nVersion=1 blocks when 95% (75% on testnet) of the network has upgraded:
-        if (block.nVersion < 2)
+        if (block.GetBaseVersion() < 2)
         {
             if ((!TestNet() && CBlockIndex::IsSuperMajority(2, pindexPrev, 950, 1000)) ||
                 (TestNet() && CBlockIndex::IsSuperMajority(2, pindexPrev, 75, 100)))
@@ -2762,7 +2762,7 @@ bool AcceptBlock(CBlock& block, CValidationState& state, CBlockIndex** ppindex, 
         }
 
     // Reject block.nVersion=2 blocks when 95% (75% on testnet) of the network has upgraded:
-    if (block.nVersion < 3)
+    if (block.GetBaseVersion() < 3)
     {
         if ((!TestNet() && CBlockIndex::IsSuperMajority(3, pindex->pprev, 950, 1000)) ||
             (TestNet() && CBlockIndex::IsSuperMajority(3, pindex->pprev, 75, 100)))
@@ -2772,7 +2772,7 @@ bool AcceptBlock(CBlock& block, CValidationState& state, CBlockIndex** ppindex, 
         }
     }
     // Enforce block.nVersion=2 rule that the coinbase starts with serialized block height
-    if (block.nVersion >= 2)
+    if (block.GetBaseVersion() >= 2)
     {
         // if 750 of the last 1,000 blocks are version 2 or greater (51/100 if testnet):
         if ((!TestNet() && CBlockIndex::IsSuperMajority(2, pindex->pprev, 750, 1000)) ||
@@ -2826,7 +2826,7 @@ bool CBlockIndex::IsSuperMajority(int minVersion, const CBlockIndex* pstart, uns
     unsigned int nFound = 0;
     for (unsigned int i = 0; i < nToCheck && nFound < nRequired && pstart != NULL; i++)
     {
-        if (pstart->nVersion >= minVersion)
+        if (pstart->GetBaseVersion() >= minVersion)
             ++nFound;
         pstart = pstart->pprev;
     }

--- a/src/main.h
+++ b/src/main.h
@@ -928,6 +928,12 @@ public:
         }
         return false;
     }
+
+    // base block version without auxpow chain
+    int GetBaseVersion() const
+    {
+        return nVersion & BLOCK_VERSION_BASE_MASK;
+    }
 };
 
 


### PR DESCRIPTION
- nVersion & 0xff to easily compare versions without aux data
- change implementations checking nVersion throughout main.ccp