### PR TITLE
[WIP] 1.8.3 supermajority fix

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -2713,10 +2713,12 @@ bool AcceptBlockHeader(CBlockHeader& block, CValidationState& state, CBlockIndex
             return state.DoS(100, error("AcceptBlock() : forked chain older than last checkpoint (height %d)", nHeight));
 
         // Reject block.nVersion=1 blocks when 95% (75% on testnet) of the network has upgraded:
+        // Dogecoin: reject ONLY if block.nVersion=3 has a supermajority because CBlockIndex::IsSuperMajority
+        //           was hard-disabled until now
         if (block.GetBaseVersion() < 2)
         {
-            if ((!TestNet() && CBlockIndex::IsSuperMajority(2, pindexPrev, 950, 1000)) ||
-                (TestNet() && CBlockIndex::IsSuperMajority(2, pindexPrev, 75, 100)))
+            if ((!TestNet() && CBlockIndex::IsSuperMajority(3, pindexPrev, 950, 1000)) ||
+                (TestNet() && CBlockIndex::IsSuperMajority(3, pindexPrev, 75, 100)))
             {
                 return state.Invalid(error("AcceptBlock() : rejected nVersion=1 block"),
                                      REJECT_OBSOLETE, "bad-version");
@@ -2772,11 +2774,13 @@ bool AcceptBlock(CBlock& block, CValidationState& state, CBlockIndex** ppindex, 
         }
     }
     // Enforce block.nVersion=2 rule that the coinbase starts with serialized block height
+    // Dogecoin: reject ONLY if block.nVersion=3 has a supermajority because CBlockIndex::IsSuperMajority
+    //           was hard-disabled until now
     if (block.GetBaseVersion() >= 2)
     {
         // if 750 of the last 1,000 blocks are version 2 or greater (51/100 if testnet):
-        if ((!TestNet() && CBlockIndex::IsSuperMajority(2, pindex->pprev, 750, 1000)) ||
-            (TestNet() && CBlockIndex::IsSuperMajority(2, pindex->pprev, 51, 100)))
+        if ((!TestNet() && CBlockIndex::IsSuperMajority(3, pindex->pprev, 750, 1000)) ||
+            (TestNet() && CBlockIndex::IsSuperMajority(3, pindex->pprev, 51, 100)))
         {
             CScript expect = CScript() << nHeight;
             if (block.vtx[0].vin[0].scriptSig.size() < expect.size() ||

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -2820,8 +2820,6 @@ bool AcceptBlock(CBlock& block, CValidationState& state, CBlockIndex** ppindex, 
 
 bool CBlockIndex::IsSuperMajority(int minVersion, const CBlockIndex* pstart, unsigned int nRequired, unsigned int nToCheck)
 {
-    // Dogecoin: temporarily disable v2 block lockin until we are ready for v2 transition
-    return false;
 
     unsigned int nFound = 0;
     for (unsigned int i = 0; i < nToCheck && nFound < nRequired && pstart != NULL; i++)

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -1967,8 +1967,8 @@ bool ConnectBlock(CBlock& block, CValidationState& state, CBlockIndex* pindex, C
                          (fStrictPayToScriptHash ? SCRIPT_VERIFY_P2SH : SCRIPT_VERIFY_NONE);
 
     if (block.GetBaseVersion() >= 3 &&
-        ((!TestNet() && CBlockIndex::IsSuperMajority(3, pindex->pprev, 750, 1000)) ||
-            (TestNet() && CBlockIndex::IsSuperMajority(3, pindex->pprev, 51, 100)))) {
+        ((!TestNet() && CBlockIndex::IsSuperMajority(3, pindex->pprev, 1500, 2000)) ||
+            (TestNet() && CBlockIndex::IsSuperMajority(3, pindex->pprev, 501, 1000)))) {
         flags |= SCRIPT_VERIFY_DERSIG;
     }
 
@@ -2717,8 +2717,8 @@ bool AcceptBlockHeader(CBlockHeader& block, CValidationState& state, CBlockIndex
         //           was hard-disabled until now
         if (block.GetBaseVersion() < 2)
         {
-            if ((!TestNet() && CBlockIndex::IsSuperMajority(3, pindexPrev, 950, 1000)) ||
-                (TestNet() && CBlockIndex::IsSuperMajority(3, pindexPrev, 75, 100)))
+            if ((!TestNet() && CBlockIndex::IsSuperMajority(3, pindexPrev, 1900, 2000)) ||
+                (TestNet() && CBlockIndex::IsSuperMajority(3, pindexPrev, 750, 1000)))
             {
                 return state.Invalid(error("AcceptBlock() : rejected nVersion=1 block"),
                                      REJECT_OBSOLETE, "bad-version");
@@ -2766,8 +2766,8 @@ bool AcceptBlock(CBlock& block, CValidationState& state, CBlockIndex** ppindex, 
     // Reject block.nVersion=2 blocks when 95% (75% on testnet) of the network has upgraded:
     if (block.GetBaseVersion() < 3)
     {
-        if ((!TestNet() && CBlockIndex::IsSuperMajority(3, pindex->pprev, 950, 1000)) ||
-            (TestNet() && CBlockIndex::IsSuperMajority(3, pindex->pprev, 75, 100)))
+        if ((!TestNet() && CBlockIndex::IsSuperMajority(3, pindex->pprev, 1900, 2000)) ||
+            (TestNet() && CBlockIndex::IsSuperMajority(3, pindex->pprev, 750, 1000)))
         {
             return state.Invalid(error("AcceptBlock() : rejected nVersion=2 block"),
                              REJECT_OBSOLETE, "bad-version");
@@ -2779,8 +2779,8 @@ bool AcceptBlock(CBlock& block, CValidationState& state, CBlockIndex** ppindex, 
     if (block.GetBaseVersion() >= 2)
     {
         // if 750 of the last 1,000 blocks are version 2 or greater (51/100 if testnet):
-        if ((!TestNet() && CBlockIndex::IsSuperMajority(3, pindex->pprev, 750, 1000)) ||
-            (TestNet() && CBlockIndex::IsSuperMajority(3, pindex->pprev, 51, 100)))
+        if ((!TestNet() && CBlockIndex::IsSuperMajority(3, pindex->pprev, 1500, 2000)) ||
+            (TestNet() && CBlockIndex::IsSuperMajority(3, pindex->pprev, 501, 1000)))
         {
             CScript expect = CScript() << nHeight;
             if (block.vtx[0].vin[0].scriptSig.size() < expect.size() ||


### PR DESCRIPTION
**Please don't merge this yet, needs ~~implementation in 1.10 AND~~ a regression test**

This PR enables the SuperMajority logic again after it's been disabled since v1.5 and proposes a solution for rejecting version1 blocks without having to retroactively hardfork the params at 1.8 fork:

We cannot enforce version 1 block rejection on the live chains with a v2 supermajority because previous clients will disagree and possibly we do not have compatibility with the existing chain. I propose that instead, we piggyback the version 3 supermajority switch to also enforce the version 2 softfork and all is good. This is the best solution I could think of in terms of code impact and backward compatibility until a v3 supermajority is reached, but I'm extremely open to suggestions.

I kept the commits split as one enables the logic and one fixes the bug with v2 softforks.