### PR TITLE
Some paper wallet fixes

### DIFF
--- a/depends/packages/fontconfig.mk
+++ b/depends/packages/fontconfig.mk
@@ -13,7 +13,13 @@ define $(package)_config_cmds
   $($(package)_autoconf)
 endef
 
+# 2.12.1 uses CHAR_WIDTH which is reserved and clashes with some glibc versions, but newer versions of fontconfig
+# have broken makefiles which needlessly attempt to re-generate headers with gperf.
+# Instead, change all uses of CHAR_WIDTH, and disable the rule that forces header re-generation.
+# This can be removed once the upstream build is fixed.
 define $(package)_build_cmds
+  sed -i 's/CHAR_WIDTH/CHARWIDTH/g' fontconfig/fontconfig.h src/fcobjshash.gperf src/fcobjs.h src/fcobjshash.h && \
+  sed -i 's/fcobjshash.h: fcobjshash.gperf/fcobjshash.h:/' src/Makefile && \
   $(MAKE)
 endef
 

--- a/depends/packages/qt.mk
+++ b/depends/packages/qt.mk
@@ -78,8 +78,6 @@ $(package)_config_opts += -reduce-exports
 $(package)_config_opts += -static
 $(package)_config_opts += -silent
 $(package)_config_opts += -v
-$(package)_config_opts += -no-feature-printer
-$(package)_config_opts += -no-feature-printdialog
 
 ifneq ($(build_os),darwin)
 $(package)_config_opts_darwin = -xplatform macx-clang-linux

--- a/src/qt/utilitydialog.cpp
+++ b/src/qt/utilitydialog.cpp
@@ -208,6 +208,7 @@ PaperWalletDialog::PaperWalletDialog(QWidget *parent) :
     ui->privateKeyText->setFont(font);
     ui->addressText->setAlignment(Qt::AlignJustify);
     ui->privateKeyText->setAlignment(Qt::AlignJustify);
+    setFixedSize(size());
 }
 
 void PaperWalletDialog::setClientModel(ClientModel *_clientModel)


### PR DESCRIPTION
Upstream removed printing more thoroughly, so revert that. Also a dependency fix that I encountered after updating my Ubuntu. And lastly setting a fixed size for the dialog as a small UX improvement. 