### PR TITLE
use a portion of the whole-number UTXOs to ensure a change output

### DIFF
--- a/test/functional/wallet-hd.py
+++ b/test/functional/wallet-hd.py
@@ -92,13 +92,15 @@ class WalletHDTest(BitcoinTestFramework):
         assert_equal(self.nodes[1].getbalance(), num_hd_adds + 1)
 
         # send a tx and make sure its using the internal chain for the changeoutput
-        txid = self.nodes[1].sendtoaddress(self.nodes[0].getnewaddress(), 1)
+        signal_amount = 1.5
+        txid = self.nodes[1].sendtoaddress(self.nodes[0].getnewaddress(), signal_amount)
         outs = self.nodes[1].decoderawtransaction(self.nodes[1].gettransaction(txid)['hex'])['vout']
+        assert_equal(len(outs), 2) # one payment and one change tx
         keypath = ""
         for out in outs:
-            if out['value'] != 1:
+            if out['value'] != signal_amount:
                 keypath = self.nodes[1].validateaddress(out['scriptPubKey']['addresses'][0])['hdkeypath']
-        
+
         assert_equal(keypath[0:7], "m/0'/1'")
 
 if __name__ == '__main__':


### PR DESCRIPTION
wallet-hd was failing in doge 1.15 and not in bitcoin 0.15. the last assert looks for a change output but there is none because the sent amount exactly equals the UTXOs of 1 coin each. Changing the test to send 1.5coins ensures a change output and the assert passes.