### PR TITLE
wallet test fee rate fix.

### DIFF
--- a/test/functional/test_framework/util.py
+++ b/test/functional/test_framework/util.py
@@ -26,6 +26,8 @@ logger = logging.getLogger("TestFramework.utils")
 
 def assert_fee_amount(fee, tx_size, fee_per_kB):
     """Assert the fee was in range"""
+    # dogecoin: tx_size <1000 is rounded up to 1000
+    tx_size = tx_size if tx_size >= 1000 else 1000
     target_fee = tx_size * fee_per_kB / 1000
     if fee < target_fee:
         raise AssertionError("Fee of %s BTC too low! (Should be %s BTC)" % (str(fee), str(target_fee)))

--- a/test/functional/wallet-hd.py
+++ b/test/functional/wallet-hd.py
@@ -92,13 +92,15 @@ class WalletHDTest(BitcoinTestFramework):
         assert_equal(self.nodes[1].getbalance(), num_hd_adds + 1)
 
         # send a tx and make sure its using the internal chain for the changeoutput
-        txid = self.nodes[1].sendtoaddress(self.nodes[0].getnewaddress(), 1)
+        signal_amount = 1.5
+        txid = self.nodes[1].sendtoaddress(self.nodes[0].getnewaddress(), signal_amount)
         outs = self.nodes[1].decoderawtransaction(self.nodes[1].gettransaction(txid)['hex'])['vout']
+        assert_equal(len(outs), 2) # one payment and one change tx
         keypath = ""
         for out in outs:
-            if out['value'] != 1:
+            if out['value'] != signal_amount:
                 keypath = self.nodes[1].validateaddress(out['scriptPubKey']['addresses'][0])['hdkeypath']
-        
+
         assert_equal(keypath[0:7], "m/0'/1'")
 
 if __name__ == '__main__':

--- a/test/functional/wallet.py
+++ b/test/functional/wallet.py
@@ -147,7 +147,7 @@ class WalletTest(BitcoinTestFramework):
 
         # Send 100000 DOGE normal
         address = self.nodes[0].getnewaddress("test")
-        fee_per_byte = Decimal('1')
+        fee_per_byte = Decimal('0.001')
         self.nodes[2].settxfee(fee_per_byte * 1000)
         txid = self.nodes[2].sendtoaddress(address, 100000, "", "", False)
         self.nodes[2].generate(1)


### PR DESCRIPTION
there was some confusion in the fee rate for wallet.py. it was set to 1doge per byte with a 226byte transaction getting rounded up to 1000bytes (a 1000doge fee), then hitting the 400doge tx absolute fee limit.

the wallet test was adjusted to 0.001doge per byte or 1doge per kilobyte, and the fee assertion knows to round up to 1000bytes when comparing the output of what bitcoind/dogecoind calculates for the fee.