### PR TITLE
test: p2p-acceptblock.py

### DIFF
--- a/src/validation.h
+++ b/src/validation.h
@@ -200,7 +200,7 @@ extern bool fPruneMode;
 /** Number of MiB of block files that we're trying to stay below. */
 extern uint64_t nPruneTarget;
 /** Block files containing a block-height within MIN_BLOCKS_TO_KEEP of chainActive.Tip() will not be pruned. */
-static const unsigned int MIN_BLOCKS_TO_KEEP = 1152;
+static const unsigned int MIN_BLOCKS_TO_KEEP = 1440;
 
 static const signed int DEFAULT_CHECKBLOCKS = 6;
 static const unsigned int DEFAULT_CHECKLEVEL = 3;


### PR DESCRIPTION
subtracted 1 from iterators as python uses zero based arrays

removed consensus of minimum blocks to keep commit atomic
